### PR TITLE
fix: 修复取消高度绝艳绝娇制裁potential条件错误导致的游戏崩溃

### DIFF
--- a/common/resolutions/CG_plus_resolutions.txt
+++ b/common/resolutions/CG_plus_resolutions.txt
@@ -702,7 +702,7 @@ resolution_sanctions_uniform_repeal_3 = {
 
 	potential = {
 		has_federations_dlc = yes
-		is_active_resolution = "resolution_sanctions_tech_3"
+		is_active_resolution = "resolution_sanctions_uniform_3"
 	}
 
 	triggered_modifier = {


### PR DESCRIPTION
取消高度绝艳绝娇制裁这个决议的potential写成了高度科研制裁
虽然UI上不会展示出来，但是AI会直接提出这个决议，如果这个决议放到银河理事会上就会导致游戏直接闪退